### PR TITLE
Fix decodeURIComponent bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3396,6 +3396,11 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-invalid-trailing-encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-invalid-trailing-encoding/-/strip-invalid-trailing-encoding-1.0.0.tgz",
+      "integrity": "sha512-M/f6vpxQ7jE3mbnx7OWbKe6K61VStiKzXTD7ai8sKl7MqBgx265nPfnpViw5VZl+9WmKYT+Fi4JSY5wo03nS8g=="
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3397,9 +3397,9 @@
       "dev": true
     },
     "strip-invalid-trailing-encoding": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-invalid-trailing-encoding/-/strip-invalid-trailing-encoding-1.0.0.tgz",
-      "integrity": "sha512-M/f6vpxQ7jE3mbnx7OWbKe6K61VStiKzXTD7ai8sKl7MqBgx265nPfnpViw5VZl+9WmKYT+Fi4JSY5wo03nS8g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strip-invalid-trailing-encoding/-/strip-invalid-trailing-encoding-1.1.0.tgz",
+      "integrity": "sha512-rDW1/6ud0lrOUJz9dREldzZf9uEMK57pkfj/ePQrNiYK2N+fDR8U5Lebf8yav+MxmbvvVSg9bHjzRHqkRoU/0w=="
     },
     "strip-json-comments": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "http-status-codes": "^1.3.0",
     "request": "^2.82.0",
     "source-map": "^0.5.7",
+    "strip-invalid-trailing-encoding": "^1.0.0",
     "winston": "^2.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "http-status-codes": "^1.3.0",
     "request": "^2.82.0",
     "source-map": "^0.5.7",
-    "strip-invalid-trailing-encoding": "^1.0.0",
+    "strip-invalid-trailing-encoding": "^1.1.0",
     "winston": "^2.3.1"
   },
   "devDependencies": {

--- a/routes/error-tracker.js
+++ b/routes/error-tracker.js
@@ -24,6 +24,7 @@ const log = require('../utils/log');
 const standardizeStackTrace = require('../utils/standardize-stack-trace');
 const ignoreMessageOrException = require('../utils/should-ignore');
 const unminify = require('../utils/unminify');
+const decode = require('../utils/decode-uri-component');
 
 /**
  * @enum {int}
@@ -44,7 +45,7 @@ function handler(req, res) {
   const params = req.query;
   const referrer = req.get('Referrer');
   const version = params.v;
-  const message = decodeURIComponent(params.m || '');
+  const message = decode(params.m || '');
 
   if (!referrer || !version || !message) {
     res.sendStatus(statusCodes.BAD_REQUEST);
@@ -74,7 +75,7 @@ function handler(req, res) {
     return null;
   }
 
-  const stack = standardizeStackTrace(decodeURIComponent(params.s || ''));
+  const stack = standardizeStackTrace(decode(params.s || ''));
   if (ignoreMessageOrException(message, stack)) {
     res.sendStatus(statusCodes.BAD_REQUEST);
     return null;
@@ -129,6 +130,7 @@ function handler(req, res) {
     resource: {
       type: 'gae_app',
       labels: {
+        module_id: 'default',
         version_id: process.env.GAE_VERSION,
       },
     },

--- a/test/unit/test-decode-uri-component.js
+++ b/test/unit/test-decode-uri-component.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const decode = require('../../utils/decode-uri-component');
+
+describe('Decode URI Component', () => {
+  it('decode encoded strings', () => {
+    const string = 'https://test.com/hello⚡';
+    expect(decode(encodeURIComponent(string))).to.equal(string);
+  });
+
+  it('handles improperly trimmed percent encodings', () => {
+    const string = 'https://test.com/hello';
+    const input = encodeURIComponent(string + '⚡').slice(0, -1);
+    expect(decode(input)).to.equal(string);
+  });
+
+  it('returns empty string on invalid encodings', () => {
+    const attack = encodeURIComponent('⚡').slice(0, -1);
+    expect(decode(attack + 'test')).to.equal('');
+  });
+});

--- a/test/unit/test-decode-uri-component.js
+++ b/test/unit/test-decode-uri-component.js
@@ -30,6 +30,9 @@ describe('Decode URI Component', () => {
 
   it('returns empty string on invalid encodings', () => {
     const attack = encodeURIComponent('⚡').slice(0, -1);
-    expect(decode(attack + 'test')).to.equal('');
+    const string = attack + 'test';
+    const result = decode(string);
+    expect(result).to.not.equal(string);
+    expect(result).to.include("URIError");
   });
 });

--- a/utils/decode-uri-component.js
+++ b/utils/decode-uri-component.js
@@ -25,7 +25,7 @@ function decode(string) {
   try {
     return decodeURIComponent(strip(string));
   } catch (e) {
-    return '';
+    return e.stack;
   }
 }
 

--- a/utils/decode-uri-component.js
+++ b/utils/decode-uri-component.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017 The AMP Authors. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const strip = require('strip-invalid-trailing-encoding');
+
+/**
+ * Decodes the string's percent encoded chars, handling invalid
+ * truncation during an escape sequence.
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function decode(string) {
+  try {
+    return decodeURIComponent(strip(string));
+  } catch (e) {
+    return '';
+  }
+}
+
+module.exports = decode;


### PR DESCRIPTION
This fixes an issue with using `decodeURIComponent` on query string parameters that (may) have been truncated on the client side. If this truncation trims a percent encoding (ie, turning `%20` into `%2`, or `%E2%9A%A1` at any point), `decodeURIComponent` throws an error.

That would mean a client side bug report now turns into a server side bug report, and we've lost information. This is happening thousands of times a day.m