### PR TITLE
Allow non-credentialed POSTs from any origin

### DIFF
--- a/app.js
+++ b/app.js
@@ -42,6 +42,10 @@ app.get('/r', (req, res) => {
   return errorTracker(req, res, req.query);
 });
 app.post('/r', json, (req, res) => {
+  // Allow non-credentialed posts from anywhere.
+  // Not strictly necessary, but it avoids an error being reported by the
+  // browser.
+  res.set('Access-Control-Allow-Origin', '*');
   return errorTracker(req, res, req.body);
 });
 


### PR DESCRIPTION
This fixes a CORs error log. This isn't strictly necessary since the
request will complete, but the browser would error saying you don't have
access to read the response (the response isn't necessary anyways).