### PR TITLE
Convert to Standard App Engine environment

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,8 +1,5 @@
-runtime: nodejs
-env: flexible
-threadsafe: true
+runtime: nodejs8
 automatic_scaling:
-  min_num_instances: 4
-  max_num_instances: 100
-  cpu_utilization:
-    target_utilization: 0.8
+  min_instances: 0
+  max_instances: 100
+  target_cpu_utilization: 0.8

--- a/app.yaml
+++ b/app.yaml
@@ -3,3 +3,4 @@ automatic_scaling:
   min_instances: 0
   max_instances: 100
   target_cpu_utilization: 0.8
+  max_concurrent_requests: 80


### PR DESCRIPTION
https://cloudplatform.googleblog.com/2018/06/Now-you-can-deploy-your-Node-js-app-to-App-Engine-standard-environment.html