### PR TITLE
Insert missing frame if no stacktrace provided

### DIFF
--- a/routes/error-tracker.js
+++ b/routes/error-tracker.js
@@ -76,7 +76,8 @@ function handler(req, res, params) {
     return null;
   }
 
-  const stack = standardizeStackTrace(safeDecodeURIComponent(params.s || ''));
+  const stack = standardizeStackTrace(safeDecodeURIComponent(params.s || ''),
+      message);
   if (ignoreMessageOrException(message, stack)) {
     res.sendStatus(statusCodes.BAD_REQUEST);
     return null;

--- a/test/e2e/test-errortracker.js
+++ b/test/e2e/test-errortracker.js
@@ -178,7 +178,7 @@ describe('Error Tracker Server', () => {
       describe('throttling', () => {
         it('does not throttle canary dev errors', () => {
           sandbox.stub(Math, 'random').returns(1);
-          const query = Object.assign({}, knownGoodQuery, {canary: '1'});
+          const query = Object.assign({}, knownGoodQuery, {canary: true});
 
           return makeRequest(referrer, query).then((res) => {
             expect(res.status).to.equal(statusCodes.ACCEPTED);
@@ -307,9 +307,11 @@ describe('Error Tracker Server', () => {
             });
           });
 
-          it('logs normalized message only', () => {
+          it('logs missing stack trace', () => {
             return makeRequest(referrer, query).then((res) => {
-              expect(res.body.event.message).to.be.equal(`Error: ${query.message}`);
+              expect(res.body.event.message).to.be.equal(
+                `Error: ${query.message}\n    at ` +
+                'the-object-does-not-support-the-operation-or-argument.js:1:1');
             });
           });
         });

--- a/test/unit/test-standardize-stack-trace.js
+++ b/test/unit/test-standardize-stack-trace.js
@@ -28,7 +28,8 @@ describe('standardizeStackTrace', () => {
       at mf.zc (https://cdn.ampproject.org/rtv/031496877433269/v0.js:408:166)
       at pf (https://cdn.ampproject.org/rtv/031496877433269/v0.js:112:409)
       at lf.$d (https://cdn.ampproject.org/rtv/031496877433269/v0.js:115:86)
-      at https://cdn.ampproject.org/rtv/031496877433269/v0.js:114:188`);
+      at https://cdn.ampproject.org/rtv/031496877433269/v0.js:114:188`,
+      'Error: localStorage not supported.');
 
     it('normalizes into 9 frames', () => {
       expect(frames).to.have.length(9);
@@ -93,7 +94,8 @@ describe('standardizeStackTrace', () => {
       $d@https://cdn.ampproject.org/v0.js:115:88
       [native code]
       https://cdn.ampproject.org/v0.js:115:170
-      promiseReactionJob@[native code]`);
+      promiseReactionJob@[native code]`,
+      'Error doing something');
 
     it('normalizes into 9 frames', () => {
       expect(frames).to.have.length(9);
@@ -143,6 +145,23 @@ describe('standardizeStackTrace', () => {
       expect(frames[6].column).to.equal(411);
       expect(frames[7].column).to.equal(88);
       expect(frames[8].column).to.equal(170);
+    });
+  });
+
+  describe('empty stack traces', () => {
+    it('inserts a missing frame for empty stacks', () => {
+      const frames = standardizeStackTrace(``, 'Error: test');
+      expect(frames.length).to.equal(1);
+      expect(frames[0].name).to.equal('');
+      expect(frames[0].source).to.equal('error-test.js');
+      expect(frames[0].line).to.equal(1);
+      expect(frames[0].column).to.equal(1);
+    });
+
+    it('generates unique filename based on message', () => {
+      const frames = standardizeStackTrace(``, 'Daisy Daisy');
+      expect(frames.length).to.equal(1);
+      expect(frames[0].source).to.equal('daisy-daisy.js');
     });
   });
 });


### PR DESCRIPTION
User Error stack traces are not recorded. At some point (maybe always?), StackDriver started requiring a stack trace in order for the error report to be generated. So, we have to insert a missing frame to generate a report.