### PR TITLE
Fix null message words bug

### DIFF
--- a/utils/standardize-stack-trace.js
+++ b/utils/standardize-stack-trace.js
@@ -85,7 +85,7 @@ function standardizeStackTrace(stack, message) {
     // Generate a unique filename based on the message's words.
     // This is to prevent StackDriver from grouping different error reports
     // together.
-    const words = message.match(/\w+/g);
+    const words = message.match(/\w+/g) || ['unknown'];
     const file = `${words.join('-').toLowerCase()}.js`;
     frames.push(new Frame('', file, '1', '1'));
   }


### PR DESCRIPTION
We're getting reports of `words.join()` failing due to `words` being
`null`.

[go/ampe/CJi--ufzuYS4ywE](http://go/ampe/CJi--ufzuYS4ywE)