### PR TITLE
Fix project client auth

### DIFF
--- a/utils/log.js
+++ b/utils/log.js
@@ -25,9 +25,11 @@ exports.errors = logging({
 }).log('javascript.errors');
 
 exports.users = logging({
+  projectId: 'amp-error-reporting-user',
   keyFilename: 'amp-error-reporting-users.json',
 }).log('javascript.errors');
 
 exports.ads = logging({
+  projectId: 'amp-error-reporting-ads',
   keyFilename: 'amp-error-reporting-ads.json',
 }).log('javascript.errors');


### PR DESCRIPTION
You have to provide a projectId, even though the docs say you don't need
to when using `keyFilename`.

Also cleans up the key file downloader.