### PR TITLE
module/nomodule support

### DIFF
--- a/test/unit/test-unminify.js
+++ b/test/unit/test-unminify.js
@@ -42,6 +42,10 @@ describe('unminify', () => {
   const versionedFrame = new Frame('test',
       'https://cdn.ampproject.org/rtv/001502924683165/v0.js', '1', '2');
   const nonCdnFrame = new Frame('test', 'http://other.com/v0.js', '1', '2');
+  const moduleFrame = new Frame('foo', 'https://cdn.ampproject.org/v0-module.js', '1',
+      '18');
+  const nomoduleFrame = new Frame('foo', 'https://cdn.ampproject.org/v0-nomodule.js', '1',
+      '18');
 
   let sandbox;
   let clock;
@@ -170,12 +174,26 @@ describe('unminify', () => {
     return unminify([frame1], '123').then(() => {
       return unminify([frame2], '124');
     }).then(() => {
-      expect(Request.request.callCount).to.equal(2);
+      return unminify([moduleFrame], '125');
+    }).then(() => {
+      expect(Request.request.callCount).to.equal(3);
       expect(Request.request.getCall(0).args[0]).to.equal(
         'https://cdn.ampproject.org/rtv/123/v0.js.map'
       );
       expect(Request.request.getCall(1).args[0]).to.equal(
         'https://cdn.ampproject.org/rtv/124/v0.js.map'
+      );
+      expect(Request.request.getCall(2).args[0]).to.equal(
+        'https://cdn.ampproject.org/rtv/125/v0-module.js.map'
+      );
+    });
+  });
+
+  it('strips nomodule during normalization', () => {
+    return unminify([nomoduleFrame], '123').then(() => {
+      expect(Request.request.callCount).to.equal(1);
+      expect(Request.request.getCall(0).args[0]).to.equal(
+        'https://cdn.ampproject.org/rtv/123/v0.js.map'
       );
     });
   });

--- a/test/unit/test-unminify.js
+++ b/test/unit/test-unminify.js
@@ -209,4 +209,77 @@ describe('unminify', () => {
       );
     });
   });
+
+  describe('URL normalization', () => {
+    const generate = function(path, extension, inputRtv, empty = false) {
+      const expectedRtv = inputRtv || 'test';
+      return [
+        {
+          input: `${inputRtv ? `rtv/${inputRtv}/` : ''}${path}${extension}`,
+          expected: empty ? '' : `rtv/${expectedRtv}/${path}${extension}`,
+        },
+        {
+          input: `${inputRtv ? `rtv/${inputRtv}/` : ''}${path}-module${extension}`,
+          expected: empty ? '' : `rtv/${expectedRtv}/${path}-module${extension}`,
+        },
+        {
+          input: `${inputRtv ? `rtv/${inputRtv}/` : ''}${path}${extension}`,
+          expected: empty ? '' : `rtv/${expectedRtv}/${path}${extension}`,
+        },
+      ];
+    };
+
+    [
+      ...generate('v0', '.js'),
+      ...generate('v1', '.js'),
+      ...generate('v20', '.js'),
+
+      // AMP extensions
+      ...generate('v0/amp-extension', '.js'),
+      ...generate('v1/amp-extension', '.js'),
+      ...generate('v1/amp-extension', '.js'),
+
+      // RTVs
+      ...generate('v0', '.js', '010123456789123'),
+      ...generate('v1', '.js', '010123456789123'),
+      ...generate('v20', '.js', '010123456789123'),
+      ...generate('v0/amp-extension', '.js', '010123456789123'),
+      ...generate('v1/amp-extension', '.js', '010123456789123'),
+      ...generate('v20/amp-extension', '.js', '010123456789123'),
+
+      // In the future, we may support mjs
+      ...generate('v0', '.mjs'),
+      ...generate('v1', '.mjs'),
+      ...generate('v20', '.mjs'),
+      ...generate('v0/amp-extension', '.mjs'),
+      ...generate('v1/amp-extension', '.mjs'),
+      ...generate('v20/amp-extension', '.mjs'),
+      ...generate('v0', '.mjs', '010123456789123'),
+      ...generate('v1', '.mjs', '010123456789123'),
+      ...generate('v20', '.mjs', '010123456789123'),
+      ...generate('v0/amp-extension', '.mjs', '010123456789123'),
+      ...generate('v1/amp-extension', '.mjs', '010123456789123'),
+      ...generate('v20/amp-extension', '.mjs', '010123456789123'),
+
+      // validator gets no love
+      ...generate('v0/validator', '.js', undefined, true),
+      ...generate('v0/validator', '.mjs', undefined, true),
+      ...generate('v0/validator', '.js', '010123456789123', true),
+      ...generate('v0/validator', '.mjs', '010123456789123', true),
+
+      // experiments gets no love
+      ...generate('v0/experiments', '.js', undefined, true),
+      ...generate('v0/experiments', '.mjs', undefined, true),
+      ...generate('v0/experiments', '.js', '010123456789123', true),
+      ...generate('v0/experiments', '.mjs', '010123456789123', true),
+    ].forEach(({input, expected}) => {
+      it(`normalizes "${input}" to "${expected}"`, () => {
+        const origin = 'https://cdn.ampproject.org/';
+        const normalized = unminify.normalizeCdnJsUrl(origin + input, 'test');
+        const actual = normalized.substr(origin.length);
+
+        expect(actual).to.equal(expected ? `${expected}.map` : '');
+      });
+    });
+  });
 });

--- a/test/unit/test-unminify.js
+++ b/test/unit/test-unminify.js
@@ -211,74 +211,815 @@ describe('unminify', () => {
   });
 
   describe('URL normalization', () => {
-    const generate = function(path, extension, inputRtv, empty = false) {
-      const expectedRtv = inputRtv || 'test';
-      return [
-        {
-          input: `${inputRtv ? `rtv/${inputRtv}/` : ''}${path}${extension}`,
-          expected: empty ? '' : `rtv/${expectedRtv}/${path}${extension}`,
-        },
-        {
-          input: `${inputRtv ? `rtv/${inputRtv}/` : ''}${path}-module${extension}`,
-          expected: empty ? '' : `rtv/${expectedRtv}/${path}-module${extension}`,
-        },
-        {
-          input: `${inputRtv ? `rtv/${inputRtv}/` : ''}${path}${extension}`,
-          expected: empty ? '' : `rtv/${expectedRtv}/${path}${extension}`,
-        },
-      ];
-    };
+    // Tests generated with:
+    // const tests = [
+    //   {
+    //     name: 'main binary',
+    //     tests: [
+    //       {
+    //         input: 'v0.js',
+    //         expected: 'rtv/RTV123/v0.js',
+    //       },
+    //     ],
+    //   },
+    // ];
+    // tests.map(({name, tests}) => {
+    //   const generated = tests.map(({input: inp, expected: exp}) => {
+    //     return (`
+    //       it('${exp}', () => {
+    //         const input = 'https://cdn.ampproject.org/${inp}';
+    //         const expected = '${exp ? `https://cdn.ampproject.org/${exp}.map` : ''}';
 
-    [
-      ...generate('v0', '.js'),
-      ...generate('v1', '.js'),
-      ...generate('v20', '.js'),
+    //         const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+    //         expect(actual).to.equal(expected);
+    //       });
+    //     `);
+    //   });
 
-      // AMP extensions
-      ...generate('v0/amp-extension', '.js'),
-      ...generate('v1/amp-extension', '.js'),
-      ...generate('v1/amp-extension', '.js'),
+    //   return (`
+    //     describe('${name}', () => {
+    //       ${generated.join('')}
+    //     });
+    //   `);
+    // }).join('');
 
-      // RTVs
-      ...generate('v0', '.js', '010123456789123'),
-      ...generate('v1', '.js', '010123456789123'),
-      ...generate('v20', '.js', '010123456789123'),
-      ...generate('v0/amp-extension', '.js', '010123456789123'),
-      ...generate('v1/amp-extension', '.js', '010123456789123'),
-      ...generate('v20/amp-extension', '.js', '010123456789123'),
+    describe('main binary', () => {
+      it('v0.js', () => {
+        const input = 'https://cdn.ampproject.org/v0.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0.js.map';
 
-      // In the future, we may support mjs
-      ...generate('v0', '.mjs'),
-      ...generate('v1', '.mjs'),
-      ...generate('v20', '.mjs'),
-      ...generate('v0/amp-extension', '.mjs'),
-      ...generate('v1/amp-extension', '.mjs'),
-      ...generate('v20/amp-extension', '.mjs'),
-      ...generate('v0', '.mjs', '010123456789123'),
-      ...generate('v1', '.mjs', '010123456789123'),
-      ...generate('v20', '.mjs', '010123456789123'),
-      ...generate('v0/amp-extension', '.mjs', '010123456789123'),
-      ...generate('v1/amp-extension', '.mjs', '010123456789123'),
-      ...generate('v20/amp-extension', '.mjs', '010123456789123'),
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
 
-      // validator gets no love
-      ...generate('v0/validator', '.js', undefined, true),
-      ...generate('v0/validator', '.mjs', undefined, true),
-      ...generate('v0/validator', '.js', '010123456789123', true),
-      ...generate('v0/validator', '.mjs', '010123456789123', true),
+      it('v0-module.js', () => {
+        const input = 'https://cdn.ampproject.org/v0-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0-module.js.map';
 
-      // experiments gets no love
-      ...generate('v0/experiments', '.js', undefined, true),
-      ...generate('v0/experiments', '.mjs', undefined, true),
-      ...generate('v0/experiments', '.js', '010123456789123', true),
-      ...generate('v0/experiments', '.mjs', '010123456789123', true),
-    ].forEach(({input, expected}) => {
-      it(`normalizes "${input}" to "${expected}"`, () => {
-        const origin = 'https://cdn.ampproject.org/';
-        const normalized = unminify.normalizeCdnJsUrl(origin + input, 'test');
-        const actual = normalized.substr(origin.length);
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
 
-        expect(actual).to.equal(expected ? `${expected}.map` : '');
+      it('v0.js', () => {
+        const input = 'https://cdn.ampproject.org/v0.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1.js', () => {
+        const input = 'https://cdn.ampproject.org/v1.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1-module.js', () => {
+        const input = 'https://cdn.ampproject.org/v1-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1.js', () => {
+        const input = 'https://cdn.ampproject.org/v1.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v20.js', () => {
+        const input = 'https://cdn.ampproject.org/v20.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v20.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v20-module.js', () => {
+        const input = 'https://cdn.ampproject.org/v20-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v20-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v20.js', () => {
+        const input = 'https://cdn.ampproject.org/v20.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v20.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+    });
+
+    describe('extensions', () => {
+      it('v0/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/v0/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/amp-extension-module.js', () => {
+        const input = 'https://cdn.ampproject.org/v0/amp-extension-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0/amp-extension-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/v0/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/v1/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1/amp-extension-module.js', () => {
+        const input = 'https://cdn.ampproject.org/v1/amp-extension-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1/amp-extension-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/v1/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/v1/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1/amp-extension-module.js', () => {
+        const input = 'https://cdn.ampproject.org/v1/amp-extension-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1/amp-extension-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/v1/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+    });
+
+    describe('rtvs', () => {
+      it('rtv/010123456789123/v0.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0-module.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1-module.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20-module.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/amp-extension-module.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1/amp-extension-module.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20/amp-extension-module.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension-module.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension-module.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20/amp-extension.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension.js';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension.js.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+    });
+
+    describe('mjs', () => {
+      it('v0.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v1.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v1-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v1.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v20.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v20.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v20.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v20-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v20-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v20-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v20.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v20.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v20.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/amp-extension-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0/amp-extension-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0/amp-extension-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v0/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v1/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1/amp-extension-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v1/amp-extension-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1/amp-extension-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v1/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v1/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v1/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v20/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v20/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v20/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v20/amp-extension-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v20/amp-extension-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v20/amp-extension-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v20/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v20/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/RTV123/v20/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/amp-extension-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v0/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1/amp-extension-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v1/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v1/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20/amp-extension-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension-module.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension-module.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v20/amp-extension.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension.mjs';
+        const expected = 'https://cdn.ampproject.org/rtv/010123456789123/v20/amp-extension.mjs.map';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+    });
+
+    describe('validator js', () => {
+      it('v0/validator.js', () => {
+        const input = 'https://cdn.ampproject.org/v0/validator.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/validator-module.js', () => {
+        const input = 'https://cdn.ampproject.org/v0/validator-module.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/validator.js', () => {
+        const input = 'https://cdn.ampproject.org/v0/validator.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/validator.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0/validator.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/validator-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0/validator-module.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/validator.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0/validator.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/validator.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/validator.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/validator-module.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/validator-module.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/validator.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/validator.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/validator.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/validator.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/validator-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/validator-module.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/validator.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/validator.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+    });
+
+    describe('experiments js', () => {
+      it('v0/experiments.js', () => {
+        const input = 'https://cdn.ampproject.org/v0/experiments.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/experiments-module.js', () => {
+        const input = 'https://cdn.ampproject.org/v0/experiments-module.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/experiments.js', () => {
+        const input = 'https://cdn.ampproject.org/v0/experiments.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/experiments.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0/experiments.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/experiments-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0/experiments-module.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('v0/experiments.mjs', () => {
+        const input = 'https://cdn.ampproject.org/v0/experiments.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/experiments.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/experiments.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/experiments-module.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/experiments-module.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/experiments.js', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/experiments.js';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/experiments.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/experiments.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/experiments-module.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/experiments-module.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
+      });
+
+      it('rtv/010123456789123/v0/experiments.mjs', () => {
+        const input = 'https://cdn.ampproject.org/rtv/010123456789123/v0/experiments.mjs';
+        const expected = '';
+
+        const actual = unminify.normalizeCdnJsUrl(input, 'RTV123');
+        expect(actual).to.equal(expected);
       });
     });
   });

--- a/utils/unminify.js
+++ b/utils/unminify.js
@@ -26,7 +26,8 @@ const Frame = require('./frame');
 const sourceMapConsumerCache = new Cache();
 const requestCache = new Map();
 
-const cdnJsRegex = new RegExp(
+const cdnJsRegex =
+  new RegExp(
     // Require the CDN URL origin at the beginning.
     '^(https://cdn\\.ampproject\\.org)' +
     // Allow, but don't require, RTV.
@@ -34,8 +35,15 @@ const cdnJsRegex = new RegExp(
     // Require text "/v" followed by digits
     '(/v\\d+' +
       // Allow, but don't require, an extension under the v0 directory.
-      // We explicitly forbid the `experiments` and `validator` "extension".
-      '(?:/(?!experiments|validator).+)?' +
+      '(?:/' +
+        // We forbid the `experiments` and `validator` psuedo-extensions.
+        '(?!(?:experiments|validator)(?:-(?:no)?module)?\\.js)' +
+        // Eat everything but the ending ".js" (nor the optional
+        // "-module"/"-nomodule" before the ending ".js")
+        '(?:(?!(?:-(?:no)?module)?\\.js$).)+' +
+      ')?' +
+    // Allow, but don't require, "-module" and "-nomodule".
+    '(?:-(no)?module)?' +
     // Require text ".js" at the end.
     '\\.js)$');
 
@@ -62,11 +70,14 @@ const nilConsumer = {
  * @return {string}
  */
 function normalizeCdnJsUrl(url, version) {
-  const [, origin, rtv, pathname] = cdnJsRegex.exec(url);
-  if (rtv) {
-    return url;
+  const [, origin, rtv, pathname, nomodule] = cdnJsRegex.exec(url);
+  if (!rtv) {
+    url = `${origin}/rtv/${version}${pathname}`;
   }
-  return `${origin}/rtv/${version}${pathname}`;
+  if (nomodule) {
+    url = url.replace(/-nomodule\.js$/, '.js');
+  }
+  return `${url}.map`;
 }
 
 /**
@@ -128,7 +139,7 @@ function extractSourceMaps(stack, version) {
       return Promise.resolve(nilConsumer);
     }
 
-    const sourceMapUrl = `${normalizeCdnJsUrl(source, version)}.map`;
+    const sourceMapUrl = normalizeCdnJsUrl(source, version);
     if (sourceMapConsumerCache.has(sourceMapUrl)) {
       return Promise.resolve(sourceMapConsumerCache.get(sourceMapUrl));
     }

--- a/utils/unminify.js
+++ b/utils/unminify.js
@@ -65,6 +65,11 @@ const nilConsumer = {
  * @return {string}
  */
 function normalizeCdnJsUrl(url, version) {
+  const match = cdnJsRegex.exec(url);
+  if (!match) {
+    return;
+  }
+
   const [
     /* full match */,
     origin,
@@ -73,7 +78,7 @@ function normalizeCdnJsUrl(url, version) {
     ampExtension,
     module = '',
     ext,
-  ] = cdnJsRegex.exec(url);
+  ] = match;
 
   // We explicitly forbid the experiments and validator "extensions" inside
   // the v0 directory.
@@ -141,11 +146,12 @@ function getSourceMapFromNetwork(url) {
  */
 function extractSourceMaps(stack, version) {
   return stack.map(({source}) => {
-    if (!cdnJsRegex.test(source)) {
+    const sourceMapUrl = normalizeCdnJsUrl(source, version);
+
+    if (!sourceMapUrl) {
       return Promise.resolve(nilConsumer);
     }
 
-    const sourceMapUrl = normalizeCdnJsUrl(source, version);
     if (sourceMapConsumerCache.has(sourceMapUrl)) {
       return Promise.resolve(sourceMapConsumerCache.get(sourceMapUrl));
     }

--- a/utils/unminify.js
+++ b/utils/unminify.js
@@ -38,7 +38,7 @@ const cdnJsRegex =
       '(?:/(.+?))?' +
     ')' +
     // Allow, but don't require, "-module" and "-nomodule".
-    '(-(?:no)?module)?' +
+    '(-(?:module|nomodule))?' +
     // Require ".js" or ".mjs" extension
     '(\\.(m)?js)$');
 


### PR DESCRIPTION
This handles fetching the map files for modules and nomodule files. It also adds support for the `.mjs` file extension, which is the common way of denoting a module file.

