### PR TITLE
Normalize source locations to .js

### DIFF
--- a/test/unit/test-standardize-stack-trace.js
+++ b/test/unit/test-standardize-stack-trace.js
@@ -81,6 +81,17 @@ describe('standardizeStackTrace', () => {
       expect(frames[7].column).to.equal(86);
       expect(frames[8].column).to.equal(188);
     });
+
+    it('normalizes .js.br files to .js', () => {
+      const frames = standardizeStackTrace(`Error: message
+        at new v1 (https://cdn.ampproject.org/rtv/031496877433269/v0.js:297:149)
+        at new v2 (https://cdn.ampproject.org/rtv/031496877433269/v0.js.br:297:149)
+      `);
+      expect(frames[0].source).to.equal(
+          'https://cdn.ampproject.org/rtv/031496877433269/v0.js');
+      expect(frames[1].source).to.equal(
+          'https://cdn.ampproject.org/rtv/031496877433269/v0.js');
+    });
   });
 
   describe('with a Safari stack trace', () => {
@@ -145,6 +156,15 @@ describe('standardizeStackTrace', () => {
       expect(frames[6].column).to.equal(411);
       expect(frames[7].column).to.equal(88);
       expect(frames[8].column).to.equal(170);
+    });
+
+    it('normalizes .js.br files to .js', () => {
+      const frames = standardizeStackTrace(`Error: message
+        jh@https://cdn.ampproject.org/v0.js:237:205
+        jh@https://cdn.ampproject.org/v0.js.br:237:205
+      `);
+      expect(frames[0].source).to.equal('https://cdn.ampproject.org/v0.js');
+      expect(frames[1].source).to.equal('https://cdn.ampproject.org/v0.js');
     });
   });
 

--- a/utils/standardize-stack-trace.js
+++ b/utils/standardize-stack-trace.js
@@ -21,6 +21,16 @@ const chromeFrame = new RegExp(`^\\s*at (?:` +
 const safariFrame = /^\s*(?:([^@\n]*)@)?([^@\n]+):(\d+):(\d+)$/gm;
 
 /**
+ * Removes the .br extension, since the file is expected to match the
+ * regular .js file.
+ * @param {string} source
+ * @return {string}
+ */
+function brotliToJs(source) {
+  return source.replace(/\.js\.br$/, '.js');
+}
+
+/**
  * Parses a Chrome formatted stack trace string.
  * @param {string} stack
  * @return {!Array<!Frame>}
@@ -32,7 +42,7 @@ function chromeStack(stack) {
   while ((match = chromeFrame.exec(stack))) {
     frames.push(new Frame(
       match[4] || '',
-      match[1] || match[5],
+      brotliToJs(match[1] || match[5]),
       match[2] || match[6],
       match[3] || match[7]
     ));
@@ -53,7 +63,7 @@ function safariStack(stack) {
   while ((match = safariFrame.exec(stack))) {
     frames.push(new Frame(
       match[1] || '',
-      match[2],
+      brotliToJs(match[2]),
       match[3],
       match[4]
     ));


### PR DESCRIPTION
This strips the trailing `.br` from files that end in `.js.br`, so that they can be aggregated as the same error originating from the regular `.js` file.

/to @choumx 