### PR TITLE
Add Cloud Build configurations for `r` and `r-beta` functions

### DIFF
--- a/cloudbuild.beta.yaml
+++ b/cloudbuild.beta.yaml
@@ -1,0 +1,7 @@
+steps:
+  # Deploy the app.
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+      - functions
+      - deploy
+      - r-beta

--- a/cloudbuild.stable.yaml
+++ b/cloudbuild.stable.yaml
@@ -1,0 +1,7 @@
+steps:
+  # Deploy the app.
+  - name: gcr.io/cloud-builders/gcloud
+    args:
+      - functions
+      - deploy
+      - r

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "start": "node server.js",
     "deploy": "gcloud functions deploy r",
+    "deploy-beta": "gcloud functions deploy r-beta",
     "lint": "prettier '**/*.js' --check",
     "pretest": "npm run lint",
     "test": "mocha test/*.js test/**/*.js"


### PR DESCRIPTION
Unlike App Engine, Cloud Functions does not provide built-in versioning or traffic migration. For this reason, we should have a "staging" error reporting function to test changes on, much like our canary releases for AMP. The AMP Runtime will (eventually, not implemented yet) report 5% (subject to change) of errors to `/r-beta` while the rest are reported to `/r`.

This PR adds an `deploy-beta` NPM script, as well as Cloud Build configurations for both functions. Once configured, these configurations will allow anyone with Pantheon access to automatically build and deploy either the beta or stable versions of error reporting. It will also allow us to automatically deploy (if desired) when a tag is pushed or when a commit is added to a given branch.

My inclination will be to auto-deploy `master` to `r-beta`, and trigger deploys to `r` by pushing a tag. We do something similar for our [GitHub Apps](https://github.com/ampproject/amp-github-apps/blob/master/DEPLOYMENT.md)