### PR TITLE
Report 410: Gone for old RTVs

### DIFF
--- a/routes/error-tracker.js
+++ b/routes/error-tracker.js
@@ -115,7 +115,7 @@ async function handler(req, res) {
   const rtvs = await latestRtv();
   // Drop requests from RTVs that are no longer being served.
   if (rtvs.length > 0 && !rtvs.includes(version)) {
-    return res.sendStatus(statusCodes.OK);
+    return res.sendStatus(statusCodes.GONE);
   }
 
   let event;


### PR DESCRIPTION
This makes it possible to differentiate between request logs that are throttled (`200: Ok`) versus requests that are dropped because of the RTV (`410: Gone`)