### PR TITLE
Log errors and failure cases as warnings

### DIFF
--- a/routes/error-tracker.js
+++ b/routes/error-tracker.js
@@ -56,6 +56,7 @@ async function buildEvent(req, reportingParams, logTarget) {
 
   const stack = standardizeStackTrace(stacktrace, message);
   if (ignoreMessageOrException(message, stack)) {
+    console.warn(`Ignored "${message}`);
     return null;
   }
   const unminifiedStack = await unminify(stack, version);
@@ -122,7 +123,7 @@ async function handler(req, res) {
   try {
     event = await buildEvent(req, reportingParams, logTarget);
   } catch (unminifyError) {
-    console.error(unminifyError);
+    console.warn('Error unminifying:', unminifyError);
     return res.sendStatus(statusCodes.UNPROCESSABLE_ENTITY);
   }
 
@@ -142,7 +143,7 @@ async function handler(req, res) {
   try {
     await logEvent(log, event);
   } catch (err) {
-    console.error(err);
+    console.warn('Error writing to log: ', err);
     debugInfo.error = writeErr.stack;
   } finally {
     if (debug) {

--- a/utils/latest-rtv.js
+++ b/utils/latest-rtv.js
@@ -70,7 +70,7 @@ module.exports = function() {
     );
     genericLog.write(entry, writeErr => {
       if (writeErr) {
-        console.error(writeErr);
+        console.warn('Error logging RTV fetch error: ', writeErr);
       }
     });
 


### PR DESCRIPTION
Logging as errors makes it way harder to find errors in the app versus errors being reported, which are also logged at the `ERROR` severity level. This logs (slightly more descriptive) warnings instead.