### PR TITLE
Log expected errors to separate log target/project

### DIFF
--- a/test/unit/test-log-target.js
+++ b/test/unit/test-log-target.js
@@ -72,6 +72,13 @@ describe('log target', () => {
 
       expect(await logTarget.log).to.equal(await logs.users);
     });
+
+    it('returns expected log for expected errors', async () => {
+      reportingParams.expected = true;
+      const logTarget = new LogTarget(referrer, reportingParams);
+
+      expect(await logTarget.log).to.equal(await logs.expected);
+    });
   });
 
   describe('serviceName', () => {

--- a/utils/log-target.js
+++ b/utils/log-target.js
@@ -35,7 +35,7 @@ module.exports = class LoggingTarget {
 
   /** Select which error logging project to report to. */
   logPromise() {
-    const { runtime, message, assert } = this.opts;
+    const { runtime, message, assert, expected } = this.opts;
 
     if (
       runtime === 'inabox' ||
@@ -46,6 +46,10 @@ module.exports = class LoggingTarget {
 
     if (assert) {
       return logs.users;
+    }
+
+    if (expected) {
+      return logs.expected;
     }
 
     return logs.errors;

--- a/utils/log.js
+++ b/utils/log.js
@@ -56,3 +56,15 @@ exports.ads = getCredentials('amp-error-reporting-ads.json')
     console.error(error);
     return exports.errors;
   });
+
+exports.expected = getCredentials('amp-error-reporting-expected.json')
+  .then(credentials =>
+    new Logging({
+      projectId: 'amp-error-reporting-expected',
+      credentials,
+    }).log('javascript.errors')
+  )
+  .catch(error => {
+    console.error(error);
+    return exports.errors;
+  });


### PR DESCRIPTION
DO NOT SUBMIT until
- [x] `amp-error-reporting-expected` project is configured
- [ ] ~the service account key is in the main project Cloud Storage~
- [x] logging of expected errors is validated via the `/r-dev` deployment target