### PR TITLE
Dedupe error source paths

### DIFF
--- a/test/unit/test-frame.js
+++ b/test/unit/test-frame.js
@@ -32,4 +32,28 @@ describe('Frame', () => {
       });
     });
   });
+
+  describe('path deduplication', () => {
+    it('fixes duplicated source paths', () => {
+      const samples = [{
+        duped: 'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
+        fixed: 'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
+      }, {
+        duped: 'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/src/service/storage-impl.js',
+        fixed: 'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/storage-impl.js',
+      }, {
+        duped: 'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src/chunk.js',
+        fixed: 'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/chunk.js',
+      }, {
+        duped: 'unexpected-token.js',
+        fixed: 'unexpected-token.js',
+      }];
+
+      samples.forEach(({duped, fixed}) => {
+        const frame = new Frame('name', duped, '1', '2');
+        console.log(duped, fixed)
+        expect(frame.source).to.equal(fixed);
+      });
+    });
+  });
 });

--- a/test/unit/test-frame.js
+++ b/test/unit/test-frame.js
@@ -35,23 +35,40 @@ describe('Frame', () => {
 
   describe('path deduplication', () => {
     it('fixes duplicated source paths', () => {
-      const samples = [{
-        duped: 'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
-        fixed: 'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
-      }, {
-        duped: 'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/src/service/storage-impl.js',
-        fixed: 'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/storage-impl.js',
-      }, {
-        duped: 'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src/chunk.js',
-        fixed: 'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/chunk.js',
-      }, {
-        duped: 'unexpected-token.js',
-        fixed: 'unexpected-token.js',
-      }];
+      const samples = [
+        {
+          duped:
+            'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
+          fixed:
+            'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
+        },
+        {
+          duped:
+            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/src/service/storage-impl.js',
+          fixed:
+            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/storage-impl.js',
+        },
+        {
+          duped:
+            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src/chunk.js',
+          fixed:
+            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/chunk.js',
+        },
+        {
+          duped:
+            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src-subdir/chunk.js',
+          fixed:
+            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src-subdir/chunk.js',
+        },
+        {
+          duped: 'unexpected-token.js',
+          fixed: 'unexpected-token.js',
+        },
+      ];
 
-      samples.forEach(({duped, fixed}) => {
+      samples.forEach(({ duped, fixed }) => {
         const frame = new Frame('name', duped, '1', '2');
-        console.log(duped, fixed)
+        console.log(duped, fixed);
         expect(frame.source).to.equal(fixed);
       });
     });

--- a/test/unit/test-frame.js
+++ b/test/unit/test-frame.js
@@ -34,41 +34,24 @@ describe('Frame', () => {
   });
 
   describe('path deduplication', () => {
-    it('fixes duplicated source paths', () => {
-      const samples = [
-        {
-          duped:
-            'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
-          fixed:
-            'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
-        },
-        {
-          duped:
-            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/src/service/storage-impl.js',
-          fixed:
-            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/storage-impl.js',
-        },
-        {
-          duped:
-            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src/chunk.js',
-          fixed:
-            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/chunk.js',
-        },
-        {
-          duped:
-            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src-subdir/chunk.js',
-          fixed:
-            'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src-subdir/chunk.js',
-        },
-        {
-          duped: 'unexpected-token.js',
-          fixed: 'unexpected-token.js',
-        },
-      ];
-
-      samples.forEach(({ duped, fixed }) => {
+    [[
+      'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
+      'https://raw.githubusercontent.com/ampproject/amphtml/2004142326360/extensions/amp-viewer-integration/0.1/messaging/messaging.js',
+    ], [
+      'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/src/service/storage-impl.js',
+      'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/service/storage-impl.js',
+    ], [
+      'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src/chunk.js',
+      'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/chunk.js',
+    ], [
+      'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src-subdir/chunk.js',
+      'https://raw.githubusercontent.com/ampproject/amphtml/2004071640410/src/src-subdir/chunk.js',
+    ], [
+      'unexpected-token.js',
+      'unexpected-token.js',
+    ]].forEach(([duped, fixed], index) => {
+      it(`fixes duplicated source paths: ${index}`, () => {
         const frame = new Frame('name', duped, '1', '2');
-        console.log(duped, fixed);
         expect(frame.source).to.equal(fixed);
       });
     });

--- a/utils/stacktrace/frame.js
+++ b/utils/stacktrace/frame.js
@@ -24,9 +24,26 @@ class Frame {
    */
   constructor(name, source, line, column) {
     this.name = name;
-    this.source = source;
+    this.source = this.dedupeSource(source);
     this.line = parseInt(line, 10);
     this.column = parseInt(column, 10);
+  }
+
+  /**
+   * Dedupes source paths.
+   * Temporary fix until #27665 fixes the sourcemaps.
+   * @param {string} source
+   * @return {string}
+   */
+  dedupeSource(source) {
+    if (!source) {
+      return source;
+    }
+
+    const matches = source.match(/ampproject\/amphtml\/\d+\/(.+)\/\1\/[^\/]+$/);
+    return matches
+      ? source.replace(`${matches[1]}/${matches[1]}`, matches[1])
+      : source;
   }
 
   /**

--- a/utils/stacktrace/frame.js
+++ b/utils/stacktrace/frame.js
@@ -13,6 +13,19 @@
  */
 
 /**
+ * Dedupes source paths.
+ * Temporary fix until #27665 fixes the sourcemaps.
+ * @param {string} source
+ * @return {string}
+ */
+function dedupeSource(source) {
+  return (
+    source &&
+    source.replace(/(ampproject\/amphtml\/\d+)(\/.+)\2(\/[^\/]+)$/, '$1$2$3')
+  );
+}
+
+/**
  * Represents a single frame in a stack trace.
  */
 class Frame {
@@ -24,26 +37,9 @@ class Frame {
    */
   constructor(name, source, line, column) {
     this.name = name;
-    this.source = this.dedupeSource(source);
+    this.source = dedupeSource(source);
     this.line = parseInt(line, 10);
     this.column = parseInt(column, 10);
-  }
-
-  /**
-   * Dedupes source paths.
-   * Temporary fix until #27665 fixes the sourcemaps.
-   * @param {string} source
-   * @return {string}
-   */
-  dedupeSource(source) {
-    if (!source) {
-      return source;
-    }
-
-    const matches = source.match(/ampproject\/amphtml\/\d+\/(.+)\/\1\/[^\/]+$/);
-    return matches
-      ? source.replace(`${matches[1]}/${matches[1]}`, matches[1])
-      : source;
   }
 
   /**


### PR DESCRIPTION
Band-aid until https://github.com/ampproject/amphtml/pull/27665 repairs the broken source-maps. Re-writes source path URLs to remove duplicated paths.