### PR TITLE
Ignore errors from Googlebot user-agents

### DIFF
--- a/routes/error-tracker.js
+++ b/routes/error-tracker.js
@@ -56,7 +56,7 @@ async function buildEvent(req, reportingParams, logTarget) {
 
   const userAgent = req.get('User-Agent');
   if (userAgent.includes('Googlebot')) {
-    console.warn(`Ignored Googlebot errror report`);
+    console.warn(`Ignored Googlebot errror report: ${message}`);
     return null;
   }
 

--- a/routes/error-tracker.js
+++ b/routes/error-tracker.js
@@ -54,6 +54,12 @@ async function logEvent(log, event) {
 async function buildEvent(req, reportingParams, logTarget) {
   const { buildQueryString, message, stacktrace, version } = reportingParams;
 
+  const userAgent = req.get('User-Agent');
+  if (userAgent.includes('Googlebot')) {
+    console.warn(`Ignored Googlebot errror report`);
+    return null;
+  }
+
   const stack = standardizeStackTrace(stacktrace, message);
   if (ignoreMessageOrException(message, stack)) {
     console.warn(`Ignored "${message}`);
@@ -79,7 +85,7 @@ async function buildEvent(req, reportingParams, logTarget) {
       httpRequest: {
         method: req.method,
         url: reqUrl,
-        userAgent: req.get('User-Agent'),
+        userAgent,
         referrer: req.get('Referrer'),
       },
     },


### PR DESCRIPTION
Sometimes, errors suddenly surge to the front page of error reporting. Upon further digging, it's revealed that almost all occurrences come from Googlebot user-agent strings. These errors are likely to be useless/distracting from real production errors.