### PR TITLE
Disable runtime filtering for pre-throttled errors

### DIFF
--- a/utils/log-target.js
+++ b/utils/log-target.js
@@ -85,11 +85,18 @@ module.exports = class LoggingTarget {
 
   /** Determine throttle level for error type. */
   get throttleRate() {
-    const { canary, binaryType, assert, referrer, expected } = this.opts;
+    const {
+      canary,
+      binaryType,
+      assert,
+      referrer,
+      expected,
+      prethrottled
+    } = this.opts;
     let throttleRate = 1;
 
-    // Throttle errors from Stable.
-    if (!canary && !['control', 'rc', 'nightly'].includes(binaryType)) {
+    // Throttle errors from Stable, unless pre-throttled on the client.
+    if (!canary && binaryType === 'production' && !prethrottled) {
       throttleRate /= 10;
     }
 

--- a/utils/log-target.js
+++ b/utils/log-target.js
@@ -91,7 +91,7 @@ module.exports = class LoggingTarget {
       assert,
       referrer,
       expected,
-      prethrottled
+      prethrottled,
     } = this.opts;
     let throttleRate = 1;
 

--- a/utils/requests/extract-reporting-params.js
+++ b/utils/requests/extract-reporting-params.js
@@ -32,7 +32,7 @@ function extractReportingParams(params) {
     expected: boolProp('ex'),
     message: safeDecodeURIComponent(strProp('m')),
     buildQueryString: () => querystring.stringify(params),
-    prethrottled: boolProp('params.pt'),
+    prethrottled: boolProp('pt'),
     runtime: params.rt,
     singlePassType: params.spt,
     stacktrace: safeDecodeURIComponent(strProp('s')),

--- a/utils/requests/extract-reporting-params.js
+++ b/utils/requests/extract-reporting-params.js
@@ -32,7 +32,7 @@ function extractReportingParams(params) {
     expected: boolProp('ex'),
     message: safeDecodeURIComponent(strProp('m')),
     buildQueryString: () => querystring.stringify(params),
-    prethrottled: boolProp('params.pt')
+    prethrottled: boolProp('params.pt'),
     runtime: params.rt,
     singlePassType: params.spt,
     stacktrace: safeDecodeURIComponent(strProp('s')),

--- a/utils/requests/extract-reporting-params.js
+++ b/utils/requests/extract-reporting-params.js
@@ -32,6 +32,7 @@ function extractReportingParams(params) {
     expected: boolProp('ex'),
     message: safeDecodeURIComponent(strProp('m')),
     buildQueryString: () => querystring.stringify(params),
+    prethrottled: boolProp('params.pt')
     runtime: params.rt,
     singlePassType: params.spt,
     stacktrace: safeDecodeURIComponent(strProp('s')),


### PR DESCRIPTION
Part of https://github.com/ampproject/error-tracker/issues/129
Accompanying change to https://github.com/ampproject/amphtml/pull/28181