### PR TITLE
Ignore stacktraces with frames from custom amp-script code

### DIFF
--- a/test/unit/test-should-ignore.js
+++ b/test/unit/test-should-ignore.js
@@ -21,12 +21,19 @@ describe('shouldIgnore', () => {
   const jsFrame = new Frame('', 'file.js', '1', '2');
   const htmlFrame = new Frame('', 'file.html', '1', '2');
   const mjsFrame = new Frame('', 'file.mjs', '1', '2');
+  const ampScriptFrame = new Frame(
+    '',
+    'amp-script[src="custom.js?v=1"].js',
+    '1',
+    '2'
+  );
 
   const jsFrames = [jsFrame, jsFrame];
   const mjsFrames = [mjsFrame, mjsFrame];
   const mixedJsFrames = [jsFrame, mjsFrame, jsFrame];
   const mixedFrames = [jsFrame, htmlFrame, jsFrame];
   const htmlFrames = [htmlFrame, htmlFrame];
+  const ampScriptFrames = [ampScriptFrame, jsFrame, ampScriptFrame, jsFrame];
 
   describe('with acceptable error message', () => {
     const message = 'Error: something happened!';
@@ -49,6 +56,10 @@ describe('shouldIgnore', () => {
 
     it('ignores html frames', () => {
       expect(shouldIgnore(message, htmlFrames)).to.equal(true);
+    });
+
+    it('ignores amp-scipt frames', () => {
+      expect(shouldIgnore(message, ampScriptFrames)).to.equal(true);
     });
   });
 

--- a/utils/stacktrace/should-ignore.js
+++ b/utils/stacktrace/should-ignore.js
@@ -23,15 +23,22 @@ const errorsToIgnore = [
   'null%20is%20not%20an%20object%20(evaluating%20%27elt.parentNode%27)',
 ];
 const JS_REGEX = /\.m?js$/;
+const AMP_SCRIPT_REGEX = /amp-script\[src=/;
+
+/**
+ * @param {!Array<!Frame>} stack
+ * @return {boolean} True if no line in the stack is from an amp-script
+ */
+function isAmpScriptStackTrace(stack) {
+  return stack.some(({ source }) => AMP_SCRIPT_REGEX.test(source));
+}
 
 /**
  * @param {!Array<!Frame>} stack
  * @return {boolean} True if its a non JS stack trace
  */
 function isNonJSStackTrace(stack) {
-  return !stack.every(({ source }) => {
-    return JS_REGEX.test(source);
-  });
+  return !stack.every(({ source }) => JS_REGEX.test(source));
 }
 
 /**
@@ -48,7 +55,11 @@ function includesBlacklistedError(message) {
  * @return {boolean}
  */
 function shouldIgnore(message, stack) {
-  return includesBlacklistedError(message) || isNonJSStackTrace(stack);
+  return (
+    includesBlacklistedError(message) ||
+    isNonJSStackTrace(stack) ||
+    isAmpScriptStackTrace(stack)
+  );
 }
 
 module.exports = shouldIgnore;


### PR DESCRIPTION
Addresses error reports like the one in https://github.com/ampproject/amphtml/issues/27904, which we can't do anything about because they are triggered by custom user code.