### PR TITLE
Un-throttle origin errors

### DIFF
--- a/test/unit/test-log-target.js
+++ b/test/unit/test-log-target.js
@@ -190,10 +190,10 @@ describe('log target', () => {
       expect(logTarget.throttleRate).to.be.closeTo(1 / 100, 1e-6);
     });
 
-    it('throttles errors from origin pages by a factor of 20', () => {
+    it('throttles errors from origin pages by a factor of 10', () => {
       referrer = 'https://myrandomwebsite.com';
       const logTarget = new LogTarget(referrer, reportingParams);
-      expect(logTarget.throttleRate).to.be.closeTo(1 / 200, 1e-6);
+      expect(logTarget.throttleRate).to.be.closeTo(1 / 10, 1e-6);
     });
 
     it('throttles expected errors by a factor of 10', () => {
@@ -202,13 +202,13 @@ describe('log target', () => {
       expect(logTarget.throttleRate).to.be.closeTo(1 / 100, 1e-6);
     });
 
-    it('throttles expected user errors in RC on origin by 2000', () => {
+    it('throttles expected user errors in RC on origin by 100', () => {
       referrer = 'https://myrandomwebsite.com';
       reportingParams.assert = true;
       reportingParams.binaryType = 'rc';
       reportingParams.expected = true;
       const logTarget = new LogTarget(referrer, reportingParams);
-      expect(logTarget.throttleRate).to.be.closeTo(1 / 2000, 1e-6);
+      expect(logTarget.throttleRate).to.be.closeTo(1 / 100, 1e-6);
     });
   });
 });

--- a/utils/log-target.js
+++ b/utils/log-target.js
@@ -105,11 +105,6 @@ module.exports = class LoggingTarget {
       throttleRate /= 10;
     }
 
-    // Throttle errors on origin pages; they may not be valid AMP docs.
-    if (!CDN_REGEX.test(referrer)) {
-      throttleRate /= 20;
-    }
-
     if (expected) {
       throttleRate /= 10;
     }


### PR DESCRIPTION
Since throttling rates are not widely known, this will make relative error volume less confusing between origin and cache buckets e.g. "this origin-only error seems insignificant relative to cache error volume".

Origin errors will also be more important as we increasingly ship divergent code between cache and origin e.g. esm.

We already sample 1/100 for pages that have non-AMP JS on the client: https://github.com/ampproject/amphtml/blob/a2abbcd652367816c17452d2d79cb92a1b6b252f/src/error.js#L320-L324

We can also consider un-throttling expected and user errors now that they're sharded into separate projects.