### PR TITLE
Fix typo that has never been hit before

### DIFF
--- a/routes/error-tracker.js
+++ b/routes/error-tracker.js
@@ -148,7 +148,7 @@ async function handler(req, res) {
     await logEvent(log, event);
   } catch (err) {
     console.warn('Error writing to log: ', err);
-    debugInfo.error = writeErr.stack;
+    debugInfo.error = err.stack;
   } finally {
     if (debug) {
       res.set('Content-Type', 'application/json; charset=utf-8');


### PR DESCRIPTION
Log ingestion limit was hit, so writing to the error log triggers an error. A typo in the error-handling code triggers an error, which attempts to log itself.

10 logging
20 causes an error which
30 attempts to log itself which
40 GOTO 20