### PR TITLE
[Cleanup] Ensure string parameters are trimmed and not null

### DIFF
--- a/utils/requests/extract-reporting-params.js
+++ b/utils/requests/extract-reporting-params.js
@@ -22,7 +22,7 @@ import safeDecodeURIComponent from 'safe-decode-uri-component';
 
 export function extractReportingParams(params) {
   const boolProp = (key) => params[key] === '1';
-  const strProp = (key) => params[key] || '';
+  const strProp = (key) => params[key]?.trim() ?? '';
 
   return {
     assert: boolProp('a'),


### PR DESCRIPTION
e.g., much older RTVs cause the `cdn` param to return a space (` `) which causes service buckets such as `Production > Publisher Origin ( )`